### PR TITLE
Fix JSON serialization + Use Java 8 kotlin-stdlib variant

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -8,7 +8,7 @@ This plugin comes to help, the JAR just needs to be dropped into the plugin dire
 
 - Kotlin v1.4.10
 - KotlinX Coroutines v1.3.9
-- KotlinX Serialization v1.0.0
+- KotlinX Serialization v1.0.1 with JSON format support
 
 ## How to use it
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.tekgator"
-version = "1.4.10.2"
+version = "1.4.10.3"
 
 repositories {
     mavenCentral()
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
+    implementation(kotlin("stdlib-jdk8"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.0.1")
     compileOnly ("org.bukkit:bukkit:1.15.2-R0.1-SNAPSHOT")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.tekgator"
-version = "1.4.10.1"
+version = "1.4.10.2"
 
 repositories {
     mavenCentral()
@@ -21,7 +21,7 @@ repositories {
 dependencies {
     implementation(kotlin("stdlib"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.0.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.0.1")
     compileOnly ("org.bukkit:bukkit:1.15.2-R0.1-SNAPSHOT")
 }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Kotlin
 description: Adds Kotlin library to Bukkit / Spigot to be used for Kotlin plugins
-version: 1.4.10.1
+version: 1.4.10.3
 main: com.tekgator.kotlinmc.KotlinBukkit
 author: Tekgator


### PR DESCRIPTION
1. At some point JSON format is not part of the core serialization artifact, which results in `ClassNotFoundException`

2. Minecraft server (and Spigot too) requires Java 8, so it's safe to include `kotlin-stdlib-jdk8` variant. This adds Java 7 + Java 8 API support like `java.util.stream.Stream.asSequence()`